### PR TITLE
Locking

### DIFF
--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -663,8 +663,9 @@ double MidiInApi :: getMessage( std::vector<unsigned char> *message )
   return timeStamp;
 }
 
+// structure should be locked before using this method
 unsigned int MidiInApi::MidiQueue::size( unsigned int *__back,
-                                         unsigned int *__front )
+                                         unsigned int *__front)
 {
   // Access back/front members exactly once and make stack copies for
   // size calculation
@@ -678,6 +679,7 @@ unsigned int MidiInApi::MidiQueue::size( unsigned int *__back,
   // to member variables are needed.
   if ( __back ) *__back = _back;
   if ( __front ) *__front = _front;
+
   return _size;
 }
 
@@ -687,6 +689,8 @@ bool MidiInApi::MidiQueue::push( const MidiInApi::MidiMessage& msg )
   // Local stack copies of front/back
   unsigned int _back, _front, _size;
 
+  lock.lock();
+
   // Get back/front indexes exactly once and calculate current size
   _size = size( &_back, &_front );
 
@@ -694,8 +698,11 @@ bool MidiInApi::MidiQueue::push( const MidiInApi::MidiMessage& msg )
   {
     ring[_back] = msg;
     back = (back+1)%ringSize;
+    lock.unlock();
     return true;
   }
+
+  lock.unlock();
 
   return false;
 }
@@ -705,11 +712,15 @@ bool MidiInApi::MidiQueue::pop( std::vector<unsigned char> *msg, double* timeSta
   // Local stack copies of front/back
   unsigned int _back, _front, _size;
 
+  lock.lock();
+
   // Get back/front indexes exactly once and calculate current size
   _size = size( &_back, &_front );
 
-  if ( _size == 0 )
+  if ( _size == 0 ) {
+    lock.unlock();
     return false;
+  }
 
   // Copy queued message to the vector pointer argument and then "pop" it.
   msg->assign( ring[_front].bytes.begin(), ring[_front].bytes.end() );
@@ -719,6 +730,9 @@ bool MidiInApi::MidiQueue::pop( std::vector<unsigned char> *msg, double* timeSta
 
   // Update front
   front = (front+1)%ringSize;
+
+  lock.unlock();
+
   return true;
 }
 

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -651,9 +651,14 @@ double MidiInApi :: getMessage( std::vector<unsigned char> *message )
     return 0.0;
   }
 
+  RtMidiError::Type err = RtMidiError::NO_ERROR;
+  std::string err_msg;
   double timeStamp;
-  if ( !inputData_.queue.pop( message, &timeStamp ) )
+  if ( !inputData_.queue.pop( message, &timeStamp, &err, &err_msg ) )
     return 0.0;
+
+  if ( err != RtMidiError::NO_ERROR )
+    error( err, err_msg );
 
   return timeStamp;
 }
@@ -695,7 +700,7 @@ bool MidiInApi::MidiQueue::push( const MidiInApi::MidiMessage& msg )
   return false;
 }
 
-bool MidiInApi::MidiQueue::pop( std::vector<unsigned char> *msg, double* timeStamp )
+bool MidiInApi::MidiQueue::pop( std::vector<unsigned char> *msg, double* timeStamp, RtMidiError::Type *err, std::string *err_msg )
 {
   // Local stack copies of front/back
   unsigned int _back, _front, _size;
@@ -709,6 +714,8 @@ bool MidiInApi::MidiQueue::pop( std::vector<unsigned char> *msg, double* timeSta
   // Copy queued message to the vector pointer argument and then "pop" it.
   msg->assign( ring[_front].bytes.begin(), ring[_front].bytes.end() );
   *timeStamp = ring[_front].timeStamp;
+  *err = ring[_front].err;
+  *err_msg = ring[_front].err_msg;
 
   // Update front
   front = (front+1)%ringSize;
@@ -1650,7 +1657,17 @@ static void *alsaMidiHandler( void *ptr )
                 << (int) ev->data.connect.dest.port
                 << std::endl;
 #endif
-      data->this_->error( RtMidiError::SYSTEM_ERROR, "Port connection has closed!" );
+      if ( data->usingCallback ) {
+        std::cerr << "\nPort connection has closed!\n\n";
+        data->this_->error( RtMidiError::SYSTEM_ERROR, "Port connection has closed!" );
+      }
+      else {
+        MidiInApi::MidiMessage err_message;
+        err_message.err = RtMidiError::SYSTEM_ERROR;
+        err_message.err_msg = "Port connection has closed";
+        if ( !data->queue.push( err_message ) )
+          std::cerr << "\nMidiInCore: message queue limit reached!!\n\n";
+      }
       break;
 
     case SND_SEQ_EVENT_QFRAME: // MIDI time code

--- a/RtMidi.cpp
+++ b/RtMidi.cpp
@@ -1650,6 +1650,7 @@ static void *alsaMidiHandler( void *ptr )
                 << (int) ev->data.connect.dest.port
                 << std::endl;
 #endif
+      data->this_->error( RtMidiError::SYSTEM_ERROR, "Port connection has closed!" );
       break;
 
     case SND_SEQ_EVENT_QFRAME: // MIDI time code
@@ -1832,6 +1833,7 @@ void MidiInAlsa :: initialize( const std::string& clientName )
   data->trigger_fds[1] = -1;
   apiData_ = (void *) data;
   inputData_.apiData = (void *) data;
+  inputData_.this_ = this;
 
   if ( pipe(data->trigger_fds) == -1 ) {
     errorString_ = "MidiInAlsa::initialize: error creating pipe objects.";

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -578,6 +578,7 @@ class RTMIDI_DLL_PUBLIC MidiInApi : public MidiApi
     RtMidiIn::RtMidiCallback userCallback;
     void *userData;
     bool continueSysex;
+    MidiInApi *this_;
 
     // Default constructor.
     RtMidiInData()

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -81,6 +81,7 @@ class RTMIDI_DLL_PUBLIC RtMidiError : public std::exception
  public:
   //! Defined RtMidiError types.
   enum Type {
+    NO_ERROR = 0,
     WARNING,           /*!< A non-critical error. */
     DEBUG_WARNING,     /*!< A non-critical error which might be useful for debugging. */
     UNSPECIFIED,       /*!< The default, unspecified error type. */
@@ -546,9 +547,13 @@ class RTMIDI_DLL_PUBLIC MidiInApi : public MidiApi
     //! Time in seconds elapsed since the previous message
     double timeStamp;
 
+    // Can also contain an error (when bytes.size() == 0)
+    RtMidiError::Type err;
+    std::string err_msg;
+
     // Default constructor.
     MidiMessage()
-      : bytes(0), timeStamp(0.0) {}
+      : bytes(0), timeStamp(0.0), err(RtMidiError::NO_ERROR) {}
   };
 
   struct MidiQueue {
@@ -561,7 +566,7 @@ class RTMIDI_DLL_PUBLIC MidiInApi : public MidiApi
     MidiQueue()
       : front(0), back(0), ringSize(0), ring(0) {}
     bool push( const MidiMessage& );
-    bool pop( std::vector<unsigned char>*, double* );
+    bool pop( std::vector<unsigned char>*, double*, RtMidiError::Type*, std::string* );
     unsigned int size( unsigned int *back=0, unsigned int *front=0 );
   };
 

--- a/RtMidi.h
+++ b/RtMidi.h
@@ -62,6 +62,7 @@
 
 #include <exception>
 #include <iostream>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -561,12 +562,14 @@ class RTMIDI_DLL_PUBLIC MidiInApi : public MidiApi
     unsigned int back;
     unsigned int ringSize;
     MidiMessage *ring;
+    std::mutex lock;
 
     // Default constructor.
     MidiQueue()
       : front(0), back(0), ringSize(0), ring(0) {}
     bool push( const MidiMessage& );
     bool pop( std::vector<unsigned char>*, double*, RtMidiError::Type*, std::string* );
+  private:
     unsigned int size( unsigned int *back=0, unsigned int *front=0 );
   };
 


### PR DESCRIPTION
The alsa-thread and main-thread can both access the queue concurrently. This may cause problems. This can be verified using helgrind:

```
==68196== Possible data race during write of size 4 at 0x4CA44B4 by thread #2
==68196== Locks held: none
==68196==    at 0x5851349: MidiInApi::MidiQueue::push(MidiInApi::MidiMessage const&) (RtMidi.cpp:696)
==68196==    by 0x5856333: alsaMidiHandler(void*) (RtMidi.cpp:1668)
==68196==    by 0x484D82A: ??? (in /usr/libexec/valgrind/vgpreload_helgrind-amd64-linux.so)
==68196==    by 0x4A2D44F: start_thread (pthread_create.c:473)
==68196==    by 0x4B5DD52: clone (clone.S:95)
==68196== 
==68196== This conflicts with a previous read of size 4 by thread #1
==68196== Locks held: none
==68196==    at 0x5851214: MidiInApi::MidiQueue::size(unsigned int*, unsigned int*) (RtMidi.cpp:671)
==68196==    by 0x585145F: MidiInApi::MidiQueue::pop(std::vector<unsigned char, std::allocator<unsigned char> >*, double*, RtMidiError::Type*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >*) (RtMidi.cpp:709)
==68196==    by 0x58516B5: MidiInApi::getMessage(std::vector<unsigned char, std::allocator<unsigned char> >*) (RtMidi.cpp:657)
==68196==    by 0x584E54F: getMessage (RtMidi.h:623)
==68196==    by 0x584E54F: __pyx_pf_6rtmidi_7_rtmidi_6MidiIn_12get_message (_rtmidi.cpp:8167)
==68196==    by 0x584E54F: __pyx_pw_6rtmidi_7_rtmidi_6MidiIn_13get_message(_object*, _object*) (_rtmidi.cpp:8133)
==68196==    by 0x53578C: ??? (in /usr/bin/python3.9)
==68196==    by 0x516542: _PyEval_EvalFrameDefault (in /usr/bin/python3.9)
==68196==    by 0x514A74: ??? (in /usr/bin/python3.9)
==68196==    by 0x51480A: _PyEval_EvalCodeWithName (in /usr/bin/python3.9)
==68196==  Address 0x4ca44b4 is 84 bytes inside a block of size 232 alloc'd
==68196==    at 0x4845033: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_helgrind-amd64-linux.so)
==68196==    by 0x58558C1: RtMidiIn::openMidiApi(RtMidi::Api, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int) (RtMidi.cpp:416)
==68196==    by 0x5855A20: RtMidiIn::RtMidiIn(RtMidi::Api, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int) (RtMidi.cpp:450)
==68196==    by 0x5848DA9: __pyx_pf_6rtmidi_7_rtmidi_6MidiIn___cinit__ (_rtmidi.cpp:7400)
==68196==    by 0x5848DA9: __pyx_pw_6rtmidi_7_rtmidi_6MidiIn_1__cinit__ (_rtmidi.cpp:7287)
==68196==    by 0x5848DA9: __pyx_tp_new_6rtmidi_7_rtmidi_MidiIn(_typeobject*, _object*, _object*) (_rtmidi.cpp:10705)
==68196==    by 0x521B55: _PyObject_MakeTpCall (in /usr/bin/python3.9)
==68196==    by 0x51B9F7: _PyEval_EvalFrameDefault (in /usr/bin/python3.9)
==68196==    by 0x514A74: ??? (in /usr/bin/python3.9)
==68196==    by 0x51480A: _PyEval_EvalCodeWithName (in /usr/bin/python3.9)
==68196==    by 0x5FB256: PyEval_EvalCode (in /usr/bin/python3.9)
==68196==    by 0x6205FA: ??? (in /usr/bin/python3.9)
==68196==    by 0x61B723: ??? (in /usr/bin/python3.9)
==68196==    by 0x61FB2C: ??? (in /usr/bin/python3.9)
==68196==  Block was alloc'd by thread #1
```

with something like:

```
#! /usr/bin/python3

import rtmidi
import time

midiin = rtmidi.MidiIn()

ports = midiin.get_ports()

nr = ports.index('CH345:CH345 MIDI 1 20:0')
midiin.open_port(nr)

while True:
    print('bla', midiin.get_message())
    time.sleep(0.1)
```

using:

```
valgrind --tool=helgrind python3 test3.py
```